### PR TITLE
Added idEndToEnd as param in pix receipts

### DIFF
--- a/lib/cdt_baas/modules/cdt_pix.rb
+++ b/lib/cdt_baas/modules/cdt_pix.rb
@@ -40,9 +40,9 @@ module CdtBaas
       generateResponse(response)
     end
 
-    def getReceipts(account, page, from = nil, to = nil)
+    def getReceipts(account, page, from = nil, to = nil, idEndToEnd = nil)
       url = pix_url
-      response = @request.get(url + LIST_PIX + "?idAccount=#{account}&page=#{page}&from=#{from}&to=#{to}", [jsonHeader])
+      response = @request.get(url + LIST_PIX + "?idAccount=#{account}&page=#{page}&from=#{from}&to=#{to}&idEndToEnd=#{idEndToEnd}", [jsonHeader])
       generateResponse(response)
     end
     

--- a/lib/cdt_baas/version.rb
+++ b/lib/cdt_baas/version.rb
@@ -1,3 +1,3 @@
 module CdtBaas
-  VERSION = "1.10.0"
+  VERSION = "1.10.1"
 end


### PR DESCRIPTION
Adiciona idEndToEnd à query string da listagem de comprovantes do PIX, para poder fazer a busca por esse parâmetro