### PR TITLE
fixing error treatment from conductor responses

### DIFF
--- a/lib/cdt_baas/errorHandler/cdt_error_handler.rb
+++ b/lib/cdt_baas/errorHandler/cdt_error_handler.rb
@@ -38,7 +38,6 @@ module CdtBaas
             @message = ""
             @errorType = nil
             hasError = false
-            
             if cdtResponse.class == Hash
                 if !cdtResponse['exception'].nil?
                     hasError = true
@@ -56,18 +55,18 @@ module CdtBaas
                     else
                         @errorType = ErrorEnum::UnknownError
                     end
-                    if !cdtResponse[:code].nil?
-                        @cdtStatus = cdtResponse[:code]
-                    elsif !cdtResponse[:status].nil?
-                        @cdtStatus = cdtResponse[:status]
+                    if !cdtResponse['code'].nil?
+                        @cdtStatus = cdtResponse['code']
+                    elsif !cdtResponse['status'].nil?
+                        @cdtStatus = cdtResponse['status']
                     end
                     generateReasons(cdtResponse)
-                elsif !cdtResponse[:message].nil? and !cdtResponse[:message].downcase.include? "success"
+                elsif !cdtResponse['message'].nil? and !cdtResponse['message'].downcase.include? 'success'
                     hasError = true
-                    @message = cdtResponse[:message]
-                elsif !cdtResponse[:error].nil?
+                    @message = cdtResponse['message']
+                elsif !cdtResponse['error'].nil?
                     hasError = true
-                    @message = cdtResponse[:message]
+                    @message = cdtResponse['message']
                     generateReasons(cdtResponse)
                     @errorType = ErrorEnum::UnknownError
                 end
@@ -77,8 +76,8 @@ module CdtBaas
 
         def generateReasons(cdtResponse)
             @reasons = []
-            if !cdtResponse[:erros].nil?
-                cdtResponse[:erros].each do |error|
+            if !cdtResponse['erros'].nil?
+                cdtResponse['erros'].each do |error|
                     reasonMessage = ""
                     if !error["field"].nil?
                         reasonMessage += error["field"]
@@ -90,10 +89,10 @@ module CdtBaas
                     reason = { message: reasonMessage, cdtCode: error["code"] }
                     @reasons << reason
                 end
-            elsif !cdtResponse[:message].nil?
-                @reasons << cdtResponse[:message]
-            elsif !cdtResponse[:error].nil?
-                @reasons << cdtResponse[:error]
+            elsif !cdtResponse['message'].nil?
+                @reasons << cdtResponse['message']
+            elsif !cdtResponse['error'].nil?
+                @reasons << cdtResponse['error']
             end
         end
     end

--- a/lib/cdt_baas/version.rb
+++ b/lib/cdt_baas/version.rb
@@ -1,3 +1,3 @@
 module CdtBaas
-  VERSION = '1.28.0'
+  VERSION = '1.28.1'
 end


### PR DESCRIPTION
Os métodos mapErrorType e generateReasons estavam utilizando a notação errada para checar os nós na response da dock, ao invés de usar a de símbolos cdtResponse[:error] devemos procurar por cdtResponse['error'] no caso dessas responses. Testando localmente vi que esse formato fazia com que não caísse nas condicionais esperadas e a response fosse tratada como sendo de sucesso, mesmo que não fosse. Isso direcionava o usuário para a tela errada no fluxo de cadastrar chaves pix quando já possui o máximo de chaves permitidas, ao invés de fazer um redirect exibindo um erro no IB do alm.